### PR TITLE
improve server to support http request handlers, this.id, and fix port

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,9 +42,17 @@ var service = {
 
     function get (id) {
       if (id === 'nobody') {
-        return new Error('nobody is not an id')
+        return new Error('nobody is not allowed.')
       }
     }
+  },
+  handlers: function (server, config) {
+    return [
+      function (req, res, next) {
+        console.log('cookie:', req.headers.cookie)
+        next()
+      }
+    ]
   }
 }
 
@@ -95,7 +103,10 @@ a `vas` service is defined by an object with the following keys:
 - `manifest`: an object [muxrpc manifest](https://github.com/ssbc/muxrpc#manifest)
 - `methods`: a `methods(server, config)` pure function that returns an object of method functions to pass into [`muxrpc`](https://github.com/ssbc/muxrpc)
 - `permissions`: a `permissions(server, config)` pure function that returns an object of permission functions which correspond to methods. each permission function accepts the same arguments as the method and can return an optional `new Error(...)` if the method should not be called.
+- `handlers` a `handlers(server, config)` pure function that returns an array of http request handler functions, each of shape `(req, res, next) => { next() }`.
 - `services`: any recursive sub-services
+
+in either a method, permission, or handler function: `this.id` corresponds to a shared value to set and get for each connection. (_hint_: auth)
 
 many `vas` services can refer to a single service or an `Array` of services
 

--- a/command.js
+++ b/command.js
@@ -22,7 +22,8 @@ function command (services, config, options, argv) {
 
   function onListen (err) {
     if (err) throw err
-    console.log(`server listening at ws://localhost:${options.port}`)
+    const url = options.url || `ws://localhost:${options.port}`
+    console.log(`server listening at ${url}`)
   }
 
   function onConnect (err, ws) {

--- a/connect.js
+++ b/connect.js
@@ -10,7 +10,7 @@ module.exports = connect
 function connect (services, config, options) {
   options = defined(options, {})
 
-  var url = defined(options.url, '')
+  var url = defined(options.url, '/')
   var onConnect = options.onConnect
 
   var client = createClient(services, config)

--- a/createServer.js
+++ b/createServer.js
@@ -12,6 +12,7 @@ function createServer (services, config) {
     manifest: {},
     permissions: {},
     methods: {},
+    handlers: [],
     createStream
   }
 
@@ -24,6 +25,8 @@ function createServer (services, config) {
     setIn(server.methods, path, service.methods && service.methods(server, config))
     // merge permissions
     setIn(server.permissions, path, service.permissions && service.permissions(server, config))
+    // merge http handlers
+    if (service.handlers) server.handlers = server.handlers.concat(service.handlers(server, config))
   })
 
   return server

--- a/createServer.js
+++ b/createServer.js
@@ -28,13 +28,12 @@ function createServer (services, config) {
 
   return server
 
-  function createStream () {
-    return createRpc().createStream()
+  function createStream (id) {
+    return createRpc(id).stream
   }
 
-  function createRpc () {
-    const Rpc = muxrpc(null, server.manifest, serialize)
-    return Rpc(server.methods, permission)
+  function createRpc (id) {
+    return muxrpc(server.manifest, server.manifest, server.methods, id, permission, serialize)
   }
 
   function permission (name, args) {

--- a/listen.js
+++ b/listen.js
@@ -1,5 +1,5 @@
 const pull = require('pull-stream')
-const Ws = require('pull-ws/server')
+const Ws = require('pull-ws')
 const defined = require('defined')
 
 const createServer = require('./createServer')

--- a/listen.js
+++ b/listen.js
@@ -4,7 +4,7 @@ const defined = require('defined')
 
 const createServer = require('./createServer')
 
-const DEFAULT_PORT = 6000
+const DEFAULT_PORT = 5000
 
 module.exports = listen
 

--- a/listen.js
+++ b/listen.js
@@ -13,17 +13,31 @@ function listen (api, config, options) {
 
   const port = defined(options.port, DEFAULT_PORT)
   const onListen = options.onListen
+  const getId = defined(options.getId, defaultGetId)
 
   const server = createServer(api, config)
   const ws = Ws.createServer(options, onConnect)
 
   return ws.listen(port, onListen)
 
-  function onConnect (stream) {
-    pull(
-      stream,
-      server.createStream(),
-      stream
-    )
+  function onConnect (ws) {
+    getId(ws, function (err, id) {
+      if (err) {
+        return pull(
+          pull.error(err),
+          ws.sink
+        )
+      }
+
+      pull(
+        ws,
+        server.createStream(id),
+        ws
+      )
+    })
   }
+}
+
+function defaultGetId (ws, cb) {
+  cb(null, null)
 }

--- a/listen.js
+++ b/listen.js
@@ -15,7 +15,7 @@ function listen (api, config, options) {
   const onListen = options.onListen
 
   const server = createServer(api, config)
-  const ws = Ws.createServer(config, onConnect)
+  const ws = Ws.createServer(options, onConnect)
 
   return ws.listen(port, onListen)
 

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "pull-serializer": "^0.3.2",
     "pull-stream": "^3.4.3",
     "pull-ws": "^3.2.2",
-    "set-in": "^2.0.0"
+    "set-in": "^2.0.0",
+    "stack": "^0.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "muxrpcli": "^1.0.5",
     "pull-serializer": "^0.3.2",
     "pull-stream": "^3.4.3",
-    "pull-ws": "^3.2.2",
+    "pull-ws": "github:pull-stream/pull-ws#fix-module-exports",
     "set-in": "^2.0.0",
     "stack": "^0.1.0"
   }


### PR DESCRIPTION
this pull request implements #8, #11, and #5.

---

original pull request below:
## add option.getId `(ws, cb) => cb(err, id)` to vas.listen

use case is to assign user id from `ws.headers.cookie` like so:

``` js
getId: (ws, cb) => { tickets.check(ws.headers.cookie, cb) }
```

where `tickets` is an instance of https://github.com/dominictarr/ticket-auth
