### PR TITLE
`2.0.0`

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ for a user interface complement, see [`inu`](https://github.com/ahdinosaur/inu)
 
 ## demos
 
-- [holodex/app#compost](https://github.com/holodex/app/tree/compost): full-stack user directory app using [`inu`](https://github.com/ahdinosaur/inu), [`inux`](https://github.com/ahdinosaur/inux), and [`vas`](https://github.com/ahdinosaur/vas)
+- [holodex/app](https://github.com/holodex/app): full-stack user directory app using [`inu`](https://github.com/ahdinosaur/inu), [`inux`](https://github.com/ahdinosaur/inux), and [`vas`](https://github.com/ahdinosaur/vas)
 
 ## example
 
@@ -119,25 +119,6 @@ the top-level `vas` module is a grab bag of all `vas/*` modules.
 
 you can also require each module separately like `require('vas/createServer')`.
 
-### `server = vas.createServer(services, config)`
-
-a `vas` server is an instantiation of a service that responds to requests.
-
-`createServer` returns an object that corresponds to the (recursive) services and respective methods returned by `methods`.
-
-### `client = vas.createClient(services, config)`
-
-a `vas` client is a composition of manifests to makes requests.
-
-`createClient` returns an object that corresponds to the (recursive) services and respective methods in `manifest`.
-
-### `server.createStream(id)`
-### `client.createStream(id)`
-
-returns a [duplex pull stream](https://github.com/dominictarr/pull-stream-examples/blob/master/duplex.js) using [`muxrpc`](https://github.com/ssbc/muxrpc)
-
-for a server, if `id` is passed in, will bind each method or permission function with `id` as `this.id`.
-
 ### `vas.listen(services, config, options)`
 
 creates a server with `createServer(services, config)`, then
@@ -148,6 +129,7 @@ listens to a port and begins to handle requests from clients using [`pull-ws-ser
 
 - `port`: port to open WebSocket server
 - `onListen`: function to call once server is listening
+- `createHttpServer`: function to create http server, of shape `(handlers) => server`. default is `(handlers) => http.createServer(Stack(...handlers))`
 
 ### `vas.connect(client, config, options)`
 
@@ -167,6 +149,27 @@ run a command on a server as a command-line interface using [`muxrpcli`](https:/
 `options` are either those passed to `vas.listen` or `vas.connect`, depending on if `argv[0] === 'server'`
 
 `argv` is expected to be `process.argv`.
+
+---
+
+### `server = vas.createServer(services, config)`
+
+a `vas` server is an instantiation of a service that responds to requests.
+
+`createServer` returns an object that corresponds to the (recursive) services and respective methods returned by `methods`.
+
+### `client = vas.createClient(services, config)`
+
+a `vas` client is a composition of manifests to makes requests.
+
+`createClient` returns an object that corresponds to the (recursive) services and respective methods in `manifest`.
+
+### `server.createStream(id)`
+### `client.createStream(id)`
+
+returns a [duplex pull stream](https://github.com/dominictarr/pull-stream-examples/blob/master/duplex.js) using [`muxrpc`](https://github.com/ssbc/muxrpc)
+
+for a server, if `id` is passed in, will bind each method or permission function with `id` as `this.id`.
 
 ## frequently asked questions (FAQ)
 

--- a/README.md
+++ b/README.md
@@ -108,9 +108,8 @@ a `vas` service is defined by an object with the following keys:
 - `methods`: a `methods(server, config)` pure function that returns an object of method functions to pass into [`muxrpc`](https://github.com/ssbc/muxrpc)
 - `permissions`: a `permissions(server, config)` pure function that returns an object of permission functions which correspond to methods. each permission function accepts the same arguments as the method and can return an optional `new Error(...)` if the method should not be called.
 - `handlers` a `handlers(server, config)` pure function that returns an array of http request handler functions, each of shape `(req, res, next) => { next() }`.
+- `authenticate`: a `authenticate(server, config)` pure function that returns an authentication function, of shape `(req, cb) => cb(err, id)`. only the first `authenticate` function will be used for a given set of services. the `id` returned by `authenticate` will be available as `this.id` in method or permission functions and `req.id` in handler functions.
 - `services`: any recursive sub-services
-
-in either a method, permission, or handler function: `this.id` corresponds to a shared value to set and get for each connection. (_hint_: auth)
 
 many `vas` services can refer to a single service or an `Array` of services
 
@@ -137,7 +136,7 @@ a `vas` client is a composition of manifests to makes requests.
 
 returns a [duplex pull stream](https://github.com/dominictarr/pull-stream-examples/blob/master/duplex.js) using [`muxrpc`](https://github.com/ssbc/muxrpc)
 
-if `id` is passed in, will bind each method function with `id` as `this.id`.
+for a server, if `id` is passed in, will bind each method or permission function with `id` as `this.id`.
 
 ### `vas.listen(services, config, options)`
 

--- a/createServer.js
+++ b/createServer.js
@@ -19,8 +19,6 @@ function createServer (services, config) {
   walk(services, function (service, path) {
     // merge manifest
     setIn(server.manifest, path, service.manifest)
-    // BACK COMPAT
-    if (!service.methods && service.init) service.methods = service.init
     // merge methods by calling service.init(service, config)
     setIn(server.methods, path, service.methods && service.methods(server, config))
     // merge permissions

--- a/createServer.js
+++ b/createServer.js
@@ -27,7 +27,10 @@ function createServer (services, config) {
     setIn(server.permissions, path, service.permissions && service.permissions(server, config))
     // merge http handlers
     if (service.handlers) server.handlers = server.handlers.concat(service.handlers(server, config))
+    if (!server.authenticate && service.authenticate) server.authenticate = service.authenticate(server, config)
   })
+
+  if (!server.authenticate) server.authenticate = defaultAuthenticate
 
   return server
 
@@ -43,4 +46,8 @@ function createServer (services, config) {
     const perm = getIn(server.permissions, name)
     return perm != null ? perm(...args) : null
   }
+}
+
+function defaultAuthenticate (req, cb) {
+  cb(null, null)
 }

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "muxrpcli": "^1.0.5",
     "pull-serializer": "^0.3.2",
     "pull-stream": "^3.4.3",
-    "pull-ws": "github:pull-stream/pull-ws#fix-module-exports",
+    "pull-ws": "^3.2.3",
     "set-in": "^2.0.0",
     "stack": "^0.1.0"
   }


### PR DESCRIPTION
so i messed up on [authentication](https://github.com/ahdinosaur/vas/issues/8), [need a breaking change to remove my mistake](https://twitter.com/dominictarr/status/698116283301122048) and replace it with something better.

the better way to do authentication:
- add `authenticate` to service definition, returns array of `(req, res, next) => { next() }`
- `server.authenticate` will be result of first `authenticate(server, config)` found by walking the services
- default `server.authenticate` returns `id` as `null`
- prefix handlers with one to set `req.id` from calling `server.authenticate`
- before creating WebSocket stream, authenticate and pass into `server.createStream(id)`

meanwhile, i'm going to remove backwards compatibility for `service.init`, which has been replaced with `service.methods`.

anything else i should change while bumping a major? hmm...

feedbacks welcome!
